### PR TITLE
refactor:Update content-type in signals zip

### DIFF
--- a/csharp/src/Signals.Library/Communication/Communication.cs
+++ b/csharp/src/Signals.Library/Communication/Communication.cs
@@ -3,6 +3,7 @@ using Signals.Library.Communication.Models;
 using Signals.Library.Constants;
 using Signals.Library.Models;
 using Signals.Library.Utility;
+using System.Net.Http.Headers;
 using System.Security;
 using System.Text;
 
@@ -144,7 +145,9 @@ namespace Signals.Library.Communication
                     new HttpRequestMessage(HttpMethod.Post, $"{SafeUrl}{ApiEndpoints.ZipSignals}");
                 signalRequest.Headers.Add("Authorization", $"Bearer {await GetAccessToken()}");
                 var content = new MultipartFormDataContent();
-                content.Add(new StreamContent(stream),"file",zipFilePath);
+                StreamContent zipContent = new StreamContent(stream);
+                zipContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+                content.Add(zipContent, "file", zipFilePath);
                 signalRequest.Content = content;
 
                 var response = await Client.SendAsync(signalRequest);


### PR DESCRIPTION
In sprint 54 we have used extra validation layer in SignalsZip API that also checks for content-type headers, added support for the same in C# code

Testing Evidences:
![image](https://github.com/Safe-Security/signal/assets/9215892/5117ff78-af8b-4a23-88e6-d26451687e30)

![image](https://github.com/Safe-Security/signal/assets/9215892/18f595d3-fc8f-48b8-99f8-52b948d2bba1)

![image](https://github.com/Safe-Security/signal/assets/9215892/b049e73a-0dc9-4949-9262-e4b6205a0256)
![image](https://github.com/Safe-Security/signal/assets/9215892/7f513eaa-c58a-49dc-b93d-dc30fd748af6)

