### PR TITLE
feat(nodejs): Supporting multiple reference links for a control

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signal-safe-security",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": "Shuva Brata Deb <shuva.d@safe.security>",
   "license": "MIT",
   "main": "lib/index.js",

--- a/nodejs/src/interfaces/signal.ts
+++ b/nodejs/src/interfaces/signal.ts
@@ -1002,6 +1002,11 @@ export interface SecurityContext{
          * Any any references to web sites or documents
          */
         reference?: string | SignalUrl;
+        
+        /**
+         * We will be deprecating 'reference' and use 'references' to support multiple reference links in future
+         */
+        references?: (string | SignalUrl)[];
 
         /**
          * Describes the impact of remediation


### PR DESCRIPTION
Updated remediation.reference to an array of strings instead of just a string and renamed to remediation.references. Since this is a breaking change, we are still supporting remediation.reference.
Updated the same at other places wherever we are using remediation.reference.